### PR TITLE
Add song filter by unit and moved song filter logics into single js file and fixed some issues in llnewunit

### DIFF
--- a/static/llsong.js
+++ b/static/llsong.js
@@ -34,8 +34,8 @@ function LLSong(songjson) {
    defaultsong2["master"] = master_default
    defaultsong2["type"] = "0"
    var songs = eval("("+songsjson+")");
-   songs["00"] = defaultsong
-   songs["01"] = defaultsong2
+   songs["-2"] = defaultsong
+   songs["-1"] = defaultsong2
 
    var attcolor = new Array();
    attcolor["smile"] = "red"
@@ -50,7 +50,10 @@ function LLSong(songjson) {
    this.songAttId = 'songatt';
    this.songUnitId = 'songunit';
    this.songSearchId = 'songsearch';
+   this.songDiffId = 'songdiff';
+   this.mapAttId = 'map';
    this.getElementValue = function (id, defaultValue) {
+      if (!id) return defaultValue;
       var ret = undefined;
       var element = document.getElementById(id);
       if (element) ret = element.value;
@@ -58,23 +61,24 @@ function LLSong(songjson) {
       return ret;
    };
    this.getElementOrThrow = function (id) {
+      if (!id) throw "Not given id";
       var ret = document.getElementById(id);
-      if (!ret) {
-         throw ("Not found " + id);
-      }
+      if (!ret) throw ("Not found " + id);
       return ret;
    };
-   this.filterSongs = function (songsel, songatt, songunit, keyword) {
+   this.filterSongs = function (songsel, songatt, songunit, songdiff, keyword) {
+      // TODO: filter by event(sm, mf, etc.), by star, by special flags (限时, 超难关, 滑键, etc.)
       if (songsel === undefined) songsel = this.getElementOrThrow(this.songSelId);
       if (songatt === undefined) songatt = this.getElementValue(this.songAttId, "");
       if (songunit === undefined) songunit = this.getElementValue(this.songUnitId, "");
+      if (songdiff === undefined) songdiff = this.getElementValue(this.songDiffId, "");
       if (keyword === undefined) keyword = this.getElementValue(this.songSearchId, "");
 
       var lastSelected = songsel.value;
       var keepLastSelected = false;
       songsel.options.length = 1;
       if (keyword) keyword = keyword.toLowerCase();
-      var songKeys = Object.keys(this.songs).sort();
+      var songKeys = Object.keys(this.songs).sort(function(a,b){return parseInt(a) - parseInt(b);});
       for (var i = 0; i < songKeys.length; i++) {
          var index = songKeys[i];
          var curSong = this.songs[index];
@@ -82,6 +86,9 @@ function LLSong(songjson) {
             continue;
          }
          if (songunit && !(curSong[songunit] == 1)) {
+            continue;
+         }
+         if (songdiff && curSong[songdiff] === undefined) {
             continue;
          }
          if (keyword && !((curSong.name.toLowerCase().indexOf(keyword) != -1) || (curSong.jpname.toLowerCase().indexOf(keyword) != -1))) {
@@ -102,7 +109,21 @@ function LLSong(songjson) {
       }
    };
    this.showAllSongs = function (songsel) {
-      this.filterSongs(songsel, "", "", "");
+      this.filterSongs(songsel, "", "", "", "");
+   };
+   this.getSelectedSongIndex = function (selid) {
+      if (selid === undefined) selid = this.songSelId;
+      return this.getElementValue(selid, "");
+   };
+   this.getSongAttr = function (songindex) {
+      if (songindex === undefined) songindex = this.getSelectedSongIndex();
+      if (songindex == "") return "";
+      var song = this.songs[songindex];
+      if (!song) return "";
+      var songattr = song.attribute;
+      if (songattr == "") songattr = this.getElementValue(this.songAttId, "");
+      if (songattr == "") songattr = this.getElementValue(this.mapAttId, "");
+      return songattr;
    };
 }
 

--- a/static/llsong.js
+++ b/static/llsong.js
@@ -1,0 +1,108 @@
+/*
+ * Common song filter/select script
+ *
+ * By ben1222
+ */
+
+function LLSong(songjson) {
+   var defaultsong = new Array()
+   defaultsong["name"] = "默认曲目（缪）"
+   defaultsong["jpname"] = "默认曲目（缪）"
+   defaultsong["muse"] = 1
+   defaultsong["aqours"] = 0
+   defaultsong['attribute'] = ''
+   var defaultsong2 = new Array()
+   defaultsong2["name"] = "默认曲目（水）"
+   defaultsong2["jpname"] = "默认曲目（水）"
+   defaultsong2["muse"] = 0
+   defaultsong2["aqours"] = 1
+   defaultsong2['attribute'] = ''
+   var expert_default = new Array()
+   expert_default["positionweight"] = [63.75,63.75,63.75,63.75,0,63.75,63.75,63.75,63.75]
+   expert_default["combo"] = 500
+   expert_default["time"] = 110
+   expert_default["star"] = 65
+   var master_default = new Array()
+   master_default["positionweight"] = [87.5,87.5,87.5,87.5,0,87.5,87.5,87.5,87.5]
+   master_default["combo"] = 700
+   master_default["time"] = 110
+   master_default["star"] = 65
+   defaultsong["expert"] = expert_default
+   defaultsong["master"] = master_default
+   defaultsong["type"] = "0"
+   defaultsong2["expert"] = expert_default
+   defaultsong2["master"] = master_default
+   defaultsong2["type"] = "0"
+   var songs = eval("("+songsjson+")");
+   songs["00"] = defaultsong
+   songs["01"] = defaultsong2
+
+   var attcolor = new Array();
+   attcolor["smile"] = "red"
+   attcolor["pure"] = "green"
+   attcolor["cool"] = "blue"
+   attcolor[""] = "purple"
+
+   this.songs = songs;
+   this.attcolor = attcolor;
+   this.language = 0;
+   this.songSelId = 'songchoice';
+   this.songAttId = 'songatt';
+   this.songUnitId = 'songunit';
+   this.songSearchId = 'songsearch';
+   this.getElementValue = function (id, defaultValue) {
+      var ret = undefined;
+      var element = document.getElementById(id);
+      if (element) ret = element.value;
+      if (ret === undefined) return defaultValue;
+      return ret;
+   };
+   this.getElementOrThrow = function (id) {
+      var ret = document.getElementById(id);
+      if (!ret) {
+         throw ("Not found " + id);
+      }
+      return ret;
+   };
+   this.filterSongs = function (songsel, songatt, songunit, keyword) {
+      if (songsel === undefined) songsel = this.getElementOrThrow(this.songSelId);
+      if (songatt === undefined) songatt = this.getElementValue(this.songAttId, "");
+      if (songunit === undefined) songunit = this.getElementValue(this.songUnitId, "");
+      if (keyword === undefined) keyword = this.getElementValue(this.songSearchId, "");
+
+      var lastSelected = songsel.value;
+      var keepLastSelected = false;
+      songsel.options.length = 1;
+      if (keyword) keyword = keyword.toLowerCase();
+      var songKeys = Object.keys(this.songs).sort();
+      for (var i = 0; i < songKeys.length; i++) {
+         var index = songKeys[i];
+         var curSong = this.songs[index];
+         if (songatt && !((songatt == curSong.attribute) || (curSong.attribute == ""))) {
+            continue;
+         }
+         if (songunit && !(curSong[songunit] == 1)) {
+            continue;
+         }
+         if (keyword && !((curSong.name.toLowerCase().indexOf(keyword) != -1) || (curSong.jpname.toLowerCase().indexOf(keyword) != -1))) {
+            continue;
+         }
+         var newOption;
+         if (this.language == 0)
+            newOption = new Option(curSong.name, index);
+         else
+            newOption = new Option(curSong.jpname, index);
+         newOption.style.color = this.attcolor[curSong.attribute];
+         songsel.options.add(newOption);
+
+         if (index == lastSelected) keepLastSelected = true;
+      }
+      if (keepLastSelected) {
+         songsel.value = lastSelected;
+      }
+   };
+   this.showAllSongs = function (songsel) {
+      this.filterSongs(songsel, "", "", "");
+   };
+}
+

--- a/static/llsong.js
+++ b/static/llsong.js
@@ -4,38 +4,43 @@
  * By ben1222
  */
 
-function LLSong(songjson) {
-   var defaultsong = new Array()
-   defaultsong["name"] = "默认曲目（缪）"
-   defaultsong["jpname"] = "默认曲目（缪）"
-   defaultsong["muse"] = 1
-   defaultsong["aqours"] = 0
-   defaultsong['attribute'] = ''
-   var defaultsong2 = new Array()
-   defaultsong2["name"] = "默认曲目（水）"
-   defaultsong2["jpname"] = "默认曲目（水）"
-   defaultsong2["muse"] = 0
-   defaultsong2["aqours"] = 1
-   defaultsong2['attribute'] = ''
-   var expert_default = new Array()
-   expert_default["positionweight"] = [63.75,63.75,63.75,63.75,0,63.75,63.75,63.75,63.75]
-   expert_default["combo"] = 500
-   expert_default["time"] = 110
-   expert_default["star"] = 65
-   var master_default = new Array()
-   master_default["positionweight"] = [87.5,87.5,87.5,87.5,0,87.5,87.5,87.5,87.5]
-   master_default["combo"] = 700
-   master_default["time"] = 110
-   master_default["star"] = 65
-   defaultsong["expert"] = expert_default
-   defaultsong["master"] = master_default
-   defaultsong["type"] = "0"
-   defaultsong2["expert"] = expert_default
-   defaultsong2["master"] = master_default
-   defaultsong2["type"] = "0"
-   var songs = eval("("+songsjson+")");
-   songs["-2"] = defaultsong
-   songs["-1"] = defaultsong2
+function LLSong(songjson, includeDefaultSong) {
+   var songs = songjson;
+   if (typeof(songs) == "string") {
+      songs = eval("("+songs+")");
+   }
+   if (includeDefaultSong === undefined || includeDefaultSong) {
+      var defaultsong = new Array()
+      defaultsong["name"] = "默认曲目（缪）"
+      defaultsong["jpname"] = "默认曲目（缪）"
+      defaultsong["muse"] = 1
+      defaultsong["aqours"] = 0
+      defaultsong['attribute'] = ''
+      var defaultsong2 = new Array()
+      defaultsong2["name"] = "默认曲目（水）"
+      defaultsong2["jpname"] = "默认曲目（水）"
+      defaultsong2["muse"] = 0
+      defaultsong2["aqours"] = 1
+      defaultsong2['attribute'] = ''
+      var expert_default = new Array()
+      expert_default["positionweight"] = [63.75,63.75,63.75,63.75,0,63.75,63.75,63.75,63.75]
+      expert_default["combo"] = 500
+      expert_default["time"] = 110
+      expert_default["star"] = 65
+      var master_default = new Array()
+      master_default["positionweight"] = [87.5,87.5,87.5,87.5,0,87.5,87.5,87.5,87.5]
+      master_default["combo"] = 700
+      master_default["time"] = 110
+      master_default["star"] = 65
+      defaultsong["expert"] = expert_default
+      defaultsong["master"] = master_default
+      defaultsong["type"] = "0"
+      defaultsong2["expert"] = expert_default
+      defaultsong2["master"] = master_default
+      defaultsong2["type"] = "0"
+      songs["-2"] = defaultsong
+      songs["-1"] = defaultsong2
+   }
 
    var attcolor = new Array();
    attcolor["smile"] = "red"
@@ -52,78 +57,99 @@ function LLSong(songjson) {
    this.songSearchId = 'songsearch';
    this.songDiffId = 'songdiff';
    this.mapAttId = 'map';
-   this.getElementValue = function (id, defaultValue) {
-      if (!id) return defaultValue;
-      var ret = undefined;
-      var element = document.getElementById(id);
-      if (element) ret = element.value;
-      if (ret === undefined) return defaultValue;
-      return ret;
-   };
-   this.getElementOrThrow = function (id) {
-      if (!id) throw "Not given id";
-      var ret = document.getElementById(id);
-      if (!ret) throw ("Not found " + id);
-      return ret;
-   };
-   this.filterSongs = function (songsel, songatt, songunit, songdiff, keyword) {
-      // TODO: filter by event(sm, mf, etc.), by star, by special flags (限时, 超难关, 滑键, etc.)
-      if (songsel === undefined) songsel = this.getElementOrThrow(this.songSelId);
-      if (songatt === undefined) songatt = this.getElementValue(this.songAttId, "");
-      if (songunit === undefined) songunit = this.getElementValue(this.songUnitId, "");
-      if (songdiff === undefined) songdiff = this.getElementValue(this.songDiffId, "");
-      if (keyword === undefined) keyword = this.getElementValue(this.songSearchId, "");
+};
 
-      var lastSelected = songsel.value;
-      var keepLastSelected = false;
-      songsel.options.length = 1;
-      if (keyword) keyword = keyword.toLowerCase();
-      var songKeys = Object.keys(this.songs).sort(function(a,b){return parseInt(a) - parseInt(b);});
-      for (var i = 0; i < songKeys.length; i++) {
-         var index = songKeys[i];
-         var curSong = this.songs[index];
-         if (songatt && !((songatt == curSong.attribute) || (curSong.attribute == ""))) {
-            continue;
-         }
-         if (songunit && !(curSong[songunit] == 1)) {
-            continue;
-         }
-         if (songdiff && curSong[songdiff] === undefined) {
-            continue;
-         }
-         if (keyword && !((curSong.name.toLowerCase().indexOf(keyword) != -1) || (curSong.jpname.toLowerCase().indexOf(keyword) != -1))) {
-            continue;
-         }
-         var newOption;
-         if (this.language == 0)
-            newOption = new Option(curSong.name, index);
-         else
-            newOption = new Option(curSong.jpname, index);
-         newOption.style.color = this.attcolor[curSong.attribute];
-         songsel.options.add(newOption);
+LLSong.prototype.initListeners = function() {
+   var me = this;
+   var funcOnSongFilterChange = function() { me.onSongFilterChange(); };
+   this._listen(this.songAttId, 'change', funcOnSongFilterChange);
+   this._listen(this.songUnitId, 'change', funcOnSongFilterChange);
+   this._listen(this.songSearchId, 'change', funcOnSongFilterChange);
+};
+LLSong.prototype._listen = function(id, e, func) {
+   if (!(id && e && func)) return;
+   var element = document.getElementById(id);
+   if (!element) return;
+   element.addEventListener(e, func);
+};
+LLSong.prototype.getElementValue = function (id, defaultValue) {
+   if (!id) return defaultValue;
+   var ret = undefined;
+   var element = document.getElementById(id);
+   if (element) ret = element.value;
+   if (ret === undefined) return defaultValue;
+   return ret;
+};
+LLSong.prototype.getElementOrThrow = function (id) {
+   if (!id) throw "Not given id";
+   var ret = document.getElementById(id);
+   if (!ret) throw ("Not found " + id);
+   return ret;
+};
+LLSong.prototype.getSelectedSongIndex = function (selid) {
+   if (selid === undefined) selid = this.songSelId;
+   return this.getElementValue(selid, "");
+};
+LLSong.prototype.getSelectedSong = function (selid) {
+   return this.songs[getSelectedSongIndex(selid)];
+};
+LLSong.prototype.getSongAttr = function (songindex) {
+   if (songindex === undefined) songindex = this.getSelectedSongIndex();
+   if (songindex == "") return "";
+   var song = this.songs[songindex];
+   if (!song) return "";
+   var songattr = song.attribute;
+   if (songattr == "") songattr = this.getElementValue(this.songAttId, "");
+   if (songattr == "") songattr = this.getElementValue(this.mapAttId, "");
+   return songattr;
+};
+LLSong.prototype.defaultOnSongFilterChange = function () {
+   this.filterSongs();
+};
+LLSong.prototype.onSongFilterChange = LLSong.prototype.defaultOnSongFilterChange;
+LLSong.prototype.filterSongs = function (songsel, songatt, songunit, songdiff, keyword) {
+   // TODO: filter by event(sm, mf, etc.), by star, by special flags (限时, 超难关, 滑键, etc.)
+   if (songsel === undefined) songsel = this.getElementOrThrow(this.songSelId);
+   if (songatt === undefined) songatt = this.getElementValue(this.songAttId, "");
+   if (songunit === undefined) songunit = this.getElementValue(this.songUnitId, "");
+   if (songdiff === undefined) songdiff = this.getElementValue(this.songDiffId, "");
+   if (keyword === undefined) keyword = this.getElementValue(this.songSearchId, "");
 
-         if (index == lastSelected) keepLastSelected = true;
+   var lastSelected = songsel.value;
+   var keepLastSelected = false;
+   songsel.options.length = 1;
+   if (keyword) keyword = keyword.toLowerCase();
+   var songKeys = Object.keys(this.songs).sort(function(a,b){return parseInt(a) - parseInt(b);});
+   for (var i = 0; i < songKeys.length; i++) {
+      var index = songKeys[i];
+      var curSong = this.songs[index];
+      if (songatt && !((songatt == curSong.attribute) || (curSong.attribute == ""))) {
+         continue;
       }
-      if (keepLastSelected) {
-         songsel.value = lastSelected;
+      if (songunit && !(curSong[songunit] == 1)) {
+         continue;
       }
-   };
-   this.showAllSongs = function (songsel) {
-      this.filterSongs(songsel, "", "", "", "");
-   };
-   this.getSelectedSongIndex = function (selid) {
-      if (selid === undefined) selid = this.songSelId;
-      return this.getElementValue(selid, "");
-   };
-   this.getSongAttr = function (songindex) {
-      if (songindex === undefined) songindex = this.getSelectedSongIndex();
-      if (songindex == "") return "";
-      var song = this.songs[songindex];
-      if (!song) return "";
-      var songattr = song.attribute;
-      if (songattr == "") songattr = this.getElementValue(this.songAttId, "");
-      if (songattr == "") songattr = this.getElementValue(this.mapAttId, "");
-      return songattr;
-   };
-}
+      if (songdiff && curSong[songdiff] === undefined) {
+         continue;
+      }
+      if (keyword && !((curSong.name.toLowerCase().indexOf(keyword) != -1) || (curSong.jpname.toLowerCase().indexOf(keyword) != -1))) {
+         continue;
+      }
+      var newOption;
+      if (this.language == 0)
+         newOption = new Option(curSong.name, index);
+      else
+         newOption = new Option(curSong.jpname, index);
+      newOption.style.color = this.attcolor[curSong.attribute];
+      songsel.options.add(newOption);
+
+      if (index == lastSelected) keepLastSelected = true;
+   }
+   if (keepLastSelected) {
+      songsel.value = lastSelected;
+   }
+};
+LLSong.prototype.showAllSongs = function (songsel) {
+   this.filterSongs(songsel, "", "", "", "");
+};
 

--- a/static/twintailosu.js
+++ b/static/twintailosu.js
@@ -53,18 +53,19 @@ function getQuery(name)
   }
      
    function getCookie(c_name)
-  {
-	if (document.cookie.length>0){
-  		c_start=document.cookie.indexOf(c_name + "=")
- 		if (c_start!=-1){ 
-    			c_start=c_start + c_name.length+1 
-    			c_end=document.cookie.indexOf(";",c_start)
-    			if (c_end==-1) c_end=document.cookie.length
-    			return unescape(document.cookie.substring(c_start,c_end))
-    		}
-  	}
-	return ""
-  }
+   {
+      if (document.cookie.length>0){
+         var adjustedCookie = " " + document.cookie;
+         c_start = adjustedCookie.indexOf(" " + c_name + "=")
+         if (c_start!=-1){ 
+            c_start=c_start + c_name.length+1 
+            c_end=document.cookie.indexOf(";",c_start)
+            if (c_end==-1) c_end=document.cookie.length
+            return unescape(document.cookie.substring(c_start,c_end))
+         }
+      }
+      return ""
+   }
   
   function delCookie(name)
 {

--- a/static/twintailosu.js
+++ b/static/twintailosu.js
@@ -56,12 +56,12 @@ function getQuery(name)
    {
       if (document.cookie.length>0){
          var adjustedCookie = " " + document.cookie;
-         c_start = adjustedCookie.indexOf(" " + c_name + "=")
+         var c_start = adjustedCookie.indexOf(" " + c_name + "=")
          if (c_start!=-1){ 
-            c_start=c_start + c_name.length+1 
-            c_end=document.cookie.indexOf(";",c_start)
-            if (c_end==-1) c_end=document.cookie.length
-            return unescape(document.cookie.substring(c_start,c_end))
+            c_start=c_start + c_name.length+2 
+            var c_end=adjustedCookie.indexOf(";",c_start)
+            if (c_end==-1) c_end=adjustedCookie.length
+            return unescape(adjustedCookie.substring(c_start,c_end))
          }
       }
       return ""

--- a/templates/llcoverage.html
+++ b/templates/llcoverage.html
@@ -6,6 +6,7 @@
 
 {% block additional_header %}
    <script type="text/javascript" src="/static/twintailosu.js?v=1.01"></script>
+   <script type="text/javascript" src="{{ url_for('static', filename='llsong.js') }}"></script>
    <script type="text/javascript" src="/static/js/highcharts/highstock.js"></script>
    <script type="text/javascript" src="/static/js/highcharts/exporting.js"></script>
    <script src="https://app.lovelivewiki.com/Maps/songsjson.js"></script>
@@ -25,6 +26,7 @@
    var regSand = new RegExp("&amp;", "g")
    var cardsjson = "{{cardsjson}}".replace(regS,'"').replace(regS2, "'").replace(regSand, '&')
    var cards = eval("("+cardsjson+")")
+   var llsong = new LLSong(songs, false); // songs defined in songsjson.js
    var attcolor = new Array();
    var mezame = 0
    var language = 0
@@ -69,11 +71,14 @@
    var skilllevel = 0
 
    function threetonumber(three){
-      result = three
-      if (result[0] == '0'){
+      var result = three
+      if (result == '0') {
+         return 0;
+      }
+      if (result[0] == '0') {
          result = result[1]+result[2]
       }
-      if (result[0] == '0'){
+      if (result[0] == '0') {
          result = result[1]
       }
       return result
@@ -128,7 +133,7 @@
    function changeskilllevel(){
       document.getElementById('skilllevel').innerHTML = String(skilllevel+1)
       index = document.getElementById('cardchoice').value
-      if (cards[index].skill){
+      if (cards[index] && cards[index].skill){
          document.getElementById('require').innerHTML = cards[index]['skilldetail'][skilllevel].require
          document.getElementById('possibility').innerHTML = cards[index]['skilldetail'][skilllevel].possibility
          document.getElementById('score').innerHTML = cards[index]['skilldetail'][skilllevel].score
@@ -136,6 +141,7 @@
    }
 
    function cardtoskilltype(c){
+      if (!c) return 0;
       if (!c.skill)
          return 0
       if ((c.skilleffect == 4) || (c.skilleffect == 5)){
@@ -301,13 +307,12 @@
    }
    
    function changeLanguage(){
-   	var cardchoice = document.getElementById("cardchoice").value
-   	var songchoice = document.getElementById("songchoice").value
-   	language = 1-language
-   	changecardselect()
-   	changesongselect()
-   	document.getElementById("cardchoice").value = cardchoice
-   	document.getElementById("songchoice").value = songchoice
+      var cardchoice = document.getElementById("cardchoice").value
+      language = 1-language
+      llsong.language = language;
+      changecardselect()
+      changesongselect()
+      document.getElementById("cardchoice").value = cardchoice
    }
    
    function changeskilltext(n){
@@ -354,94 +359,15 @@
    	changeavatarselect()
    }
 
-   function getsongselect(diff, att, cnhave, type){
-   	sel = document.getElementById("songchoice");
-      diffc = document.getElementById('diff').value
-   	var keyword = document.getElementById("songsearch").value
-   	var smnum = ''
-      var mfnum = ''
-   	sel.options.length = 1;
-   	for (index in songs){
-   		if (((att == "") || (att == songs[index].attribute)) && ((cnhave == "") || (cnhave == songs[index]['hard']['cnhave'])) && ((type == "") || (songs[index].type.indexOf(type) != -1))){
-   		if ((keyword == "") || (songs[index].name.toLowerCase().indexOf(keyword.toLowerCase()) != -1) || (songs[index].jpname.toLowerCase().indexOf(keyword.toLowerCase()) != -1)){
-   			smhave = false
-   			if (smnum != ""){
-               if (diffc == ''){
-   			      smList = songs[index]['hard'].sm.split(" ")
-                  if (songs[index]['expert'] != null)
-                     smList = (songs[index]['hard'].sm+' '+songs[index]['expert'].sm).split(" ")
-               }
-               else if (diffc == 'expert'){
-                  smList = []
-                  if (songs[index]['expert'] != null)
-                     smList = songs[index]['expert'].sm.split(" ")
-               }
-               else{
-                  smList = songs[index]['hard'].sm.split(" ")
-               }
-   				for (i in smList){
-   					if (smnum == smList[i]){
-   						smhave = true
-   						break
-   					}
-   				}
-   			}
-            mfhave = false
-            if (mfnum != ""){
-               if (diffc == ''){
-                  mfList = songs[index]['hard'].mf.split(" ")
-                  if (songs[index]['expert'] != null)
-                     mfList = (songs[index]['hard'].mf+' '+songs[index]['expert'].mf).split(" ")
-               }
-               else if (diffc == 'expert'){
-                  mfList = []
-                  if (songs[index]['expert'] != null)
-                     mfList = songs[index]['expert'].mf.split(" ")
-               }
-               else{
-                  mfList = songs[index]['hard'].mf.split(" ")
-               }
-               for (i in mfList){
-                  if (mfnum == mfList[i]){
-                     mfhave = true
-                     break
-                  }
-               }
-            }
-   			//alert(smhave)
-   			if (((smnum == "") || smhave) && ((mfnum == "") || mfhave)){
-   				var newOption
-   				if (language == 0)
-   					newOption = new Option(songs[index].name, index)
-   				else
-   					newOption = new Option(songs[index].jpname, index)
-   				newOption.style.color = attcolor[songs[index].attribute]
-   				sel.options.add(newOption)
-   			}
-            
-   		}
-   		}
-   		index += 1
-   	}
-   	//changesongcolor("songchoice")
-   }
-   
    function changesongselect(){
-   	diff = document.getElementById("diff").value
-   	att = document.getElementById("songatt").value
-   	//type = document.getElementById("songtype").value
-   	var songchoice = document.getElementById("songchoice").value
-   	getsongselect(diff, att, '', '')
-   	if (havevalue("songchoice", songchoice)){
-   		document.getElementById("songchoice").value = songchoice
-   	}
-   	changesonginfo("songchoice")
+      llsong.filterSongs();
+      changesonginfo("songchoice")
    }
    
    function changediffinfo(){
       savediff = document.getElementById('diffchoice').value
       index = document.getElementById('songchoice').value
-      diffc = document.getElementById('diff').value
+      diffc = document.getElementById('songdiff').value
       //smnum =document.getElementById("smfilter").value
       //mfnum =document.getElementById("mffilter").value
 
@@ -493,9 +419,7 @@
     }
    
    function changesonginfo(which){
-    index = document.getElementById(which).value
-   	diff = document.getElementById('diffchoice').value
-	document.getElementById("songchoice").style.color = attcolor[songs[document.getElementById("songchoice").value].attribute]
+      document.getElementById("songchoice").style.color = llsong.attcolor[llsong.getSongAttr()]
    }
    
    function copyTo(n){
@@ -602,8 +526,9 @@
    	if (language == "")
    		language = 0
    	
+      llsong.language = language;
+      llsong.showAllSongs();
    	getcardselect("", "", "", "", "");
-   	getsongselect("", "", "", "");
    	var inputs = document.getElementsByTagName("input");
    	var selects = document.getElementsByTagName("select");
 	var nospan = document.getElementsByTagName("nospan");
@@ -635,10 +560,9 @@
 		}
    	}
    	document.getElementById("songsearch").value = ""
-   	//changecolor("cardchoice")
-   	//changesongcolor("songchoice")
-   	document.getElementById("songchoice").style.color = attcolor[songs[document.getElementById("songchoice").value].attribute]
-   	document.getElementById("cardchoice").style.color = attcolor[cards[document.getElementById("cardchoice").value].attribute]
+      // above codes may select songs/cards/filters according to cookies, so refresh it...
+      changesongselect();
+      changecardselect();
    }
    
    </script>
@@ -667,18 +591,24 @@
 <form action="" id="unitform" name="unitform" method="POST" onsubmit="return check()" enctype=multipart/form-data>
 <h3>Live信息</h3>
 搜索：<input type="text" id="songsearch" name="songsearch" value="" onchange="changesongselect()"></input><br>
-筛选：<select id="diff" name="diff" onchange="changesongselect();changediffinfo();changespeeds()" style="display:none">
+筛选：<select id="songdiff" name="songdiff" onchange="changesongselect();changediffinfo();changespeeds()">
 		<option value="">难度</option>
-		<option value="easy">easy</option>
-		<option value="normal">normal</option>
-		<option value="hard">hard</option>
-		<option value="expert">expert</option>
+		<option value="easy">包含easy难度</option>
+		<option value="normal">包含normal难度</option>
+		<option value="hard">包含hard难度</option>
+		<option value="expert">包含expert难度</option>
+		<option value="master">包含master难度</option>
 	</select>
 	<select id="songatt" name="songatt" onchange="changesongselect()">
 		<option value="">属性</option>
 		<option value="smile">smile</option>
 		<option value="pure">pure</option>
 		<option value="cool">cool</option>
+	</select>
+	<select id="songunit" name="songunit" onchange="changesongselect()">
+		<option value="">组合</option>
+		<option value="muse">μ's</option>
+		<option value="aqours">Aqours</option>
 	</select>
 <br>
 歌曲：<select id="songchoice" name="songchoice" onchange="changediffinfo();changesonginfo('songchoice');changespeeds()">

--- a/templates/llnewautounit.html
+++ b/templates/llnewautounit.html
@@ -6,6 +6,7 @@
 
 {% block additional_header %}
    <script type="text/javascript" src="{{ url_for('static', filename='twintailosu.js') }}?v=1.01"></script>
+   <script type="text/javascript" src="{{ url_for('static', filename='llsong.js') }}"></script>
    <link rel="shortcut icon" href="/static/shortcuticon.png" />
    <style type="text/css">
    	img {height:65px;width:65px}
@@ -17,46 +18,18 @@
    var regS = new RegExp("&#34;", "g")
    var regS2 = new RegExp("&#39;", "g")
    var regSand = new RegExp("&amp;", "g")
-   var defaultsong = new Array()
-   defaultsong["name"] = "默认曲目（缪）"
-   defaultsong["jpname"] = "默认曲目（缪）"
-   defaultsong["muse"] = 1
-   defaultsong["aqours"] = 0
-   defaultsong['attribute'] = 'smile'
-   var defaultsong2 = new Array()
-   defaultsong2["name"] = "默认曲目（水）"
-   defaultsong2["jpname"] = "默认曲目（水）"
-   defaultsong2["muse"] = 0
-   defaultsong2["aqours"] = 1
-   defaultsong2['attribute'] = 'smile'
-   expert_default = new Array()
-   expert_default["positionweight"] = [63.75,63.75,63.75,63.75,0,63.75,63.75,63.75,63.75]
-   expert_default["combo"] = 500
-   expert_default["time"] = 110
-   expert_default["star"] = 65
-   master_default = new Array()
-   master_default["positionweight"] = [87.5,87.5,87.5,87.5,0,87.5,87.5,87.5,87.5]
-   master_default["combo"] = 700
-   master_default["time"] = 110
-   master_default["star"] = 65
-   defaultsong["expert"] = expert_default
-   defaultsong["master"] = master_default
-   defaultsong["type"] = "0"
-   defaultsong2["expert"] = expert_default
-   defaultsong2["master"] = master_default
-   defaultsong2["type"] = "0"
    var cardsjson = "{{cardsjson}}".replace(regS,'"').replace(regS2, "'").replace(regSand, '&')
    var songsjson = "{{songsjson}}".replace(regS,'"').replace(regS2, "'").replace(regSand, '&')
    var cards = eval("("+cardsjson+")")
-   var songs = eval("("+songsjson+")")
-   songs["00"] = defaultsong
-   songs["01"] = defaultsong2
+   var llsong = new LLSong(songsjson);
+
    var attcolor = new Array();
    var mezame = 0
    var language = 0
    attcolor["smile"] = "red"
    attcolor["pure"] = "green"
    attcolor["cool"] = "blue"
+   attcolor[""] = "purple"
    var kizuna = new Array();
    kizuna["N"] = [25, 50]
    kizuna["R"] = [100, 200]
@@ -121,12 +94,15 @@
    currslot=0;
    songweight=new Array();
    songweightsort=new Array()
-function threetonumber(three){
-      result = three
-      if (result[0] == '0'){
+   function threetonumber(three){
+      var result = three
+      if (result == '0') {
+         return 0;
+      }
+      if (result[0] == '0') {
          result = result[1]+result[2]
       }
-      if (result[0] == '0'){
+      if (result[0] == '0') {
          result = result[1]
       }
       return result
@@ -333,36 +309,6 @@ function threetonumber(three){
       //changecolor("cardchoice")
    }
    
-   function getsongselect(att){
-      sel = document.getElementById("songchoice");
-      var keyword = document.getElementById("songsearch").value
-      sel.options.length = 1;
-      newOption = new Option(songs["00"].name, "00")
-      newOption.style.color = attcolor[songs["00"].attribute]
-      sel.options.add(newOption)
-      newOption = new Option(songs["01"].name, "01")
-      newOption.style.color = attcolor[songs["01"].attribute]
-      sel.options.add(newOption)
-      for (index in songs){
-         if (((att == "") || (att == songs[index].attribute))){
-         if ((keyword == "") || (songs[index].name.toLowerCase().indexOf(keyword.toLowerCase()) != -1) || (songs[index].jpname.toLowerCase().indexOf(keyword.toLowerCase()) != -1) || (songs[index].type != "0")){
-            mfhave = false
-            //alert(smhave)
-               var newOption
-               if (language == 0)
-                  newOption = new Option(songs[index].name, index)
-               else
-                  newOption = new Option(songs[index].jpname, index)
-               newOption.style.color = attcolor[songs[index].attribute]
-               sel.options.add(newOption)
-
-         }
-         }
-         index += 1
-      }
-      //changesongcolor("songchoice")
-   }
-   
    function havevalue(selectId, value){
    	objSelect = document.getElementById(selectId)
    	for (var i = 0; i < objSelect.options.length; i++){
@@ -373,13 +319,8 @@ function threetonumber(three){
    }
    
    function changesongselect(){
-   	att = document.getElementById("songatt").value
-   	var songchoice = document.getElementById("songchoice").value
-   	getsongselect(att)
-   	if (havevalue("songchoice", songchoice)){
-   		document.getElementById("songchoice").value = songchoice
-   	}
-   	changesongcolor("songchoice")
+      llsong.filterSongs();
+      changesongcolor("songchoice")
    }
    
    function changecardselect(){
@@ -431,41 +372,42 @@ function threetonumber(three){
    }
    
    function changesongcolor(which){
-   	index = document.getElementById(which).value
-      diff = document.getElementById('diffchoice').value
-   	if (index != "") {
-   		c = attcolor[songs[index].attribute]
-   		document.getElementById(which).style.color = c
-//         document.getElementById("secondbase").innerHTML = songs[index].attribute
-         document.getElementById("secondbase2").innerHTML = songs[index].attribute
-   		selectlist = ["map",  "bonus2"]
-   		for (i in selectlist){
-   			document.getElementById(selectlist[i]).value = songs[index].attribute
-   		}
+      var index = llsong.getSelectedSongIndex(which);
+      if (index != "") {
+         var diff = document.getElementById('diffchoice').value;
+         var songattr = llsong.getSongAttr(index);
+
+         var c = attcolor[songattr];
+         document.getElementById(which).style.color = c;
+//         document.getElementById("secondbase").innerHTML = songattr
+         document.getElementById("secondbase2").innerHTML = songattr;
+         selectlist = ["map",  "bonus2"];
+         for (i in selectlist){
+            document.getElementById(selectlist[i]).value = songattr;
+         }
 //   		if (document.getElementById("percentage").value != 12)
-//   			document.getElementById("base").value = songs[index].attribute
-   		if (document.getElementById("percentage2").value != 12)
-   			document.getElementById("base2").value = songs[index].attribute
-   		infolist = ["combo",  "time"]
-   		for (i in infolist){
-   			document.getElementById(infolist[i]).value = songs[index][diff][infolist[i]]
-   		}
+//   			document.getElementById("base").value = songattr
+         if (document.getElementById("percentage2").value != 12)
+            document.getElementById("base2").value = songattr;
+         infolist = ["combo",  "time"]
+         for (i in infolist){
+            document.getElementById(infolist[i]).value = llsong.songs[index][diff][infolist[i]]
+         }
          if (document.getElementById("time").value == ""){
             document.getElementById("time").value = 110
          }
          totalweight = 0
          for (i = 0; i < 9; i++)
-            totalweight += parseFloat(songs[index][diff]['positionweight'][i])
-         c = parseInt(songs[index][diff].combo)
+            totalweight += parseFloat(llsong.songs[index][diff]['positionweight'][i])
+         c = parseInt(llsong.songs[index][diff].combo)
          sl = (totalweight-c)*100/0.25/c
          //document.getElementById('slider').value = sl.toFixed(1)
-   		document.getElementById("perfect").value = parseInt(parseInt(document.getElementById("combo").value)*19/20)
-   		document.getElementById("starperfect").value = 0//parseInt(parseInt(document.getElementById("star").value)*19/20)
-   		for (i = 0; i < 9; i++){
-   			document.getElementById("weight"+String(i)).value = parseFloat(songs[index][diff]["positionweight"][i])
-   		}
-		
-   	}
+         document.getElementById("perfect").value = parseInt(parseInt(document.getElementById("combo").value)*19/20)
+         document.getElementById("starperfect").value = 0//parseInt(parseInt(document.getElementById("star").value)*19/20)
+         for (i = 0; i < 9; i++){
+            document.getElementById("weight"+String(i)).value = parseFloat(llsong.songs[index][diff]["positionweight"][i])
+         }
+      }
    }
    
    function cardidtoindex(n){
@@ -581,13 +523,12 @@ function threetonumber(three){
    }
    
    function changeLanguage(){
-   	var cardchoice = document.getElementById("cardchoice").value
-   	var songchoice = document.getElementById("songchoice").value
-   	language = 1-language
-   	changecardselect()
-   	changesongselect()
-   	document.getElementById("cardchoice").value = cardchoice
-   	document.getElementById("songchoice").value = songchoice
+      var cardchoice = document.getElementById("cardchoice").value
+      language = 1-language
+      llsong.language = language;
+      changecardselect()
+      changesongselect()
+      document.getElementById("cardchoice").value = cardchoice
    }
    
    function changeskilltext(n){
@@ -737,8 +678,11 @@ function threetonumber(three){
    	if (language == "")
    		language = 0
    	
+      llsong.language = language;
+      llsong.onSongFilterChange = changesongselect;
+      llsong.showAllSongs();
+      llsong.initListeners();
    	getcardselect("", "", "", "", "", "");
-   	getsongselect("", "", "", "");
    	var inputs = document.getElementsByTagName("input");
    	var selects = document.getElementsByTagName("select");
    	for (var i=0; i<inputs.length; i++){
@@ -763,10 +707,9 @@ function threetonumber(three){
          calslot(i)
    	}
    	document.getElementById("songsearch").value = ""
-   	//changecolor("cardchoice")
-   	//changesongcolor("songchoice")
-   	document.getElementById("songchoice").style.color = attcolor[songs[document.getElementById("songchoice").value].attribute]
-   	document.getElementById("cardchoice").style.color = attcolor[cards[document.getElementById("cardchoice").value].attribute]
+      // above codes may select songs/cards/filters according to cookies, so refresh it...
+      llsong.onSongFilterChange();
+      changecardselect();
 	document.getElementById("submembersoperation").style.display="none"
    }
    
@@ -780,7 +723,7 @@ function threetonumber(three){
       finddiff = false
       for (i in diffname){
          diff = diffname[i]
-         if (songs[index][diff] != null){
+         if (llsong.songs[index][diff] != null){
 
                   newOption = new Option(diff, diff)
                   diffsel.options.add(newOption)
@@ -1209,20 +1152,20 @@ function calc_bestarm(){
 			submember.push(subunit)
 		}
 	}
-	//计算所有加成，和最高属性
-	function setsubmemAddition(){
-		mainp=document.getElementById("map").value
-		mapsong=songs[document.getElementById('songchoice').value]
-		for (var memi in submember) {
+   //计算所有加成，和最高属性
+   function setsubmemAddition(){
+      var mainp=document.getElementById("map").value
+      var mapsong=llsong.getSelectedSong();
+      for (var memi in submember) {
          groupbonus = samegroup(mapsong,cards[submember[memi]["cardid"]])
          colorbonus = (mainp == submember[memi]['main'])
-		 submember[memi]["addition"]=1.21
+         submember[memi]["addition"]=1.21
          if (!groupbonus && !colorbonus)
             submember[memi]["addition"]=1
          else if (!groupbonus || !colorbonus)
             submember[memi]["addition"]=1.1
       }
-	}
+   }
 	function getMaxeight(){
 		unitmembers=new Array()
 		subunitmembers=new Array()
@@ -1729,7 +1672,7 @@ function calc_bestarm(){
       totalrawst = 0
       for (var i = 0; i < 9; i++) {
          totalrawst += rawattst[i]
-         groupbonus = samegroup(songs[document.getElementById('songchoice').value],cards[member[i]["cardid"]])
+         groupbonus = samegroup(llsong.getSelectedSong(),cards[member[i]["cardid"]])
          colorbonus = (mapcenter['map'] == member[i]['main'])
          if (!groupbonus && !colorbonus)
             attst[i] -= Math.round(showatt*member[i]['weight']/totalweight*0.21/1.21)
@@ -1774,7 +1717,7 @@ function calc_bestarm(){
       */
       result['minscore'] = 0;
       for (var i = 0; i < 9; i++) {
-         //result['minscore'] += Math.floor(showatt/80*member[i]['weight']*combomulti*accmulti*(mapcenter['map'] === member[i]['main'] ? 1.1 : 1)*(samegroup(songs[document.getElementById('songchoice').value],cards[member[i]["cardid"]]) ? 1.1 : 1));
+         //result['minscore'] += Math.floor(showatt/80*member[i]['weight']*combomulti*accmulti*(mapcenter['map'] === member[i]['main'] ? 1.1 : 1)*(samegroup(llsong.getSelectedSong(),cards[member[i]["cardid"]]) ? 1.1 : 1));
       }
       result['minscore'] = 1.21*totalattst/80*totalweight*combomulti*accmulti*(1+mapcenter['tapup']/100)
       
@@ -2064,13 +2007,18 @@ function calc_bestarm(){
 <form action="" id="unitform" name="unitform" method="POST" onsubmit="return check()" enctype=multipart/form-data>
 <!--<form action="/llloadunit"  onsubmit=""  target="if">-->
 <h3>歌曲信息</h3>
-搜索：<input type="text" id="songsearch" name="songsearch" value="" onchange="changesongselect()"></input><br>
+搜索：<input type="text" id="songsearch" name="songsearch" value=""></input><br>
 筛选：
-	<select id="songatt" name="songatt" onchange="changesongselect()">
+	<select id="songatt" name="songatt">
 		<option value="">属性</option>
 		<option value="smile">smile</option>
 		<option value="pure">pure</option>
 		<option value="cool">cool</option>
+	</select>
+	<select id="songunit" name="songunit">
+		<option value="">组合</option>
+		<option value="muse">μ's</option>
+		<option value="aqours">Aqours</option>
 	</select><br>
 歌曲：<select id="songchoice" name="songchoice" onchange="changediffinfo();changesongcolor('songchoice')">
 		<option value=""> </option>

--- a/templates/llnewunit.html
+++ b/templates/llnewunit.html
@@ -6,6 +6,7 @@
 
 {% block additional_header %}
    <script type="text/javascript" src="{{ url_for('static', filename='twintailosu.js') }}?v=1.01"></script>
+   <script type="text/javascript" src="{{ url_for('static', filename='llsong.js') }}"></script>
    <link rel="shortcut icon" href="/static/shortcuticon.png" />
    <style type="text/css">
       img {height:65px;width:65px}
@@ -27,40 +28,11 @@
    var regS = new RegExp("&#34;", "g")
    var regS2 = new RegExp("&#39;", "g")
    var regSand = new RegExp("&amp;", "g")
-   var defaultsong = new Array()
-   defaultsong["name"] = "默认曲目（缪）"
-   defaultsong["jpname"] = "默认曲目（缪）"
-   defaultsong["muse"] = 1
-   defaultsong["aqours"] = 0
-   defaultsong['attribute'] = ''
-   var defaultsong2 = new Array()
-   defaultsong2["name"] = "默认曲目（水）"
-   defaultsong2["jpname"] = "默认曲目（水）"
-   defaultsong2["muse"] = 0
-   defaultsong2["aqours"] = 1
-   defaultsong2['attribute'] = ''
-   expert_default = new Array()
-   expert_default["positionweight"] = [63.75,63.75,63.75,63.75,0,63.75,63.75,63.75,63.75]
-   expert_default["combo"] = 500
-   expert_default["time"] = 110
-   expert_default["star"] = 65
-   master_default = new Array()
-   master_default["positionweight"] = [87.5,87.5,87.5,87.5,0,87.5,87.5,87.5,87.5]
-   master_default["combo"] = 700
-   master_default["time"] = 110
-   master_default["star"] = 65
-   defaultsong["expert"] = expert_default
-   defaultsong["master"] = master_default
-   defaultsong["type"] = "0"
-   defaultsong2["expert"] = expert_default
-   defaultsong2["master"] = master_default
-   defaultsong2["type"] = "0"
    var cardsjson = "{{cardsjson}}".replace(regS,'"').replace(regS2, "'").replace(regSand, '&')
    var songsjson = "{{songsjson}}".replace(regS,'"').replace(regS2, "'").replace(regSand, '&')
    var cards = eval("("+cardsjson+")")
-   var songs = eval("("+songsjson+")")
-   songs["00"] = defaultsong
-   songs["01"] = defaultsong2
+   var llsong = new LLSong(songsjson);
+
    var attcolor = new Array();
    var mezame = 0
    var language = 0
@@ -289,33 +261,6 @@
       //changecolor("cardchoice")
    }
 
-   function getsongselect(songatt, songunit, keyword){
-      var sel = document.getElementById("songchoice");
-      sel.options.length = 1;
-      var songKeys = Object.keys(songs).sort();
-      for (var i = 0; i < songKeys.length; i++) {
-         var index = songKeys[i];
-         if (!((songatt == "") || (songatt == songs[index].attribute) || (songs[index].attribute == ""))) {
-            continue;
-         }
-         if (!((songunit == "") || (songs[index][songunit] == 1))) {
-            continue;
-         }
-         if (!((keyword == "") || (songs[index].name.toLowerCase().indexOf(keyword) != -1) || (songs[index].jpname.toLowerCase().indexOf(keyword) != -1))) {
-            continue;
-         }
-         //mfhave = false
-         //alert(smhave)
-         var newOption
-         if (language == 0)
-            newOption = new Option(songs[index].name, index)
-         else
-            newOption = new Option(songs[index].jpname, index)
-         newOption.style.color = attcolor[songs[index].attribute]
-         sel.options.add(newOption)
-      }
-   }
-
    function havevalue(selectId, value){
    	objSelect = document.getElementById(selectId)
    	for (var i = 0; i < objSelect.options.length; i++){
@@ -326,14 +271,7 @@
    }
 
    function changesongselect(){
-      var songatt = document.getElementById("songatt").value
-      var songunit = document.getElementById("songunit").value
-      var songchoice = document.getElementById("songchoice").value
-      var keyword = document.getElementById("songsearch").value.toLowerCase();
-      getsongselect(songatt, songunit, keyword)
-      if (havevalue("songchoice", songchoice)){
-         document.getElementById("songchoice").value = songchoice
-      }
+      llsong.filterSongs();
       changesongcolor("songchoice")
    }
 
@@ -389,7 +327,7 @@
       var index = document.getElementById(which).value;
       var diff = document.getElementById('diffchoice').value;
       if (index != "") {
-         var songattr = songs[index].attribute;
+         var songattr = llsong.songs[index].attribute;
          if (songattr == '') {
             songattr = document.getElementById("songatt").value;
             if (songattr == '') {
@@ -411,21 +349,21 @@
             document.getElementById("base2").value = songattr;
          infolist = ["combo",  "time"]
          for (i in infolist){
-            document.getElementById(infolist[i]).value = songs[index][diff][infolist[i]]
+            document.getElementById(infolist[i]).value = llsong.songs[index][diff][infolist[i]]
          }
          if (document.getElementById("time").value == ""){
             document.getElementById("time").value = 110
          }
          totalweight = 0
          for (i = 0; i < 9; i++)
-            totalweight += parseFloat(songs[index][diff]['positionweight'][i])
-         c = parseInt(songs[index][diff].combo)
+            totalweight += parseFloat(llsong.songs[index][diff]['positionweight'][i])
+         c = parseInt(llsong.songs[index][diff].combo)
          sl = (totalweight-c)*100/0.25/c
          //document.getElementById('slider').value = sl.toFixed(1)
          document.getElementById("perfect").value = parseInt(parseInt(document.getElementById("combo").value)*19/20)
          document.getElementById("starperfect").value = 0//parseInt(parseInt(document.getElementById("star").value)*19/20)
          for (i = 0; i < 9; i++){
-            document.getElementById("weight"+String(i)).value = parseFloat(songs[index][diff]["positionweight"][i])
+            document.getElementById("weight"+String(i)).value = parseFloat(llsong.songs[index][diff]["positionweight"][i])
          }
       }
    }
@@ -527,13 +465,12 @@
    }
 
    function changeLanguage(){
-   	var cardchoice = document.getElementById("cardchoice").value
-   	var songchoice = document.getElementById("songchoice").value
-   	language = 1-language
-   	changecardselect()
-   	changesongselect()
-   	document.getElementById("cardchoice").value = cardchoice
-   	document.getElementById("songchoice").value = songchoice
+      var cardchoice = document.getElementById("cardchoice").value
+      language = 1-language
+      llsong.language = language;
+      changecardselect()
+      changesongselect()
+      document.getElementById("cardchoice").value = cardchoice
    }
 
    function changeskilltext(n){
@@ -629,8 +566,9 @@
       if (language == "")
          language = 0
 
+      llsong.language = language;
+      llsong.showAllSongs();
       getcardselect("", "", "", "", "", "");
-      getsongselect("", "", "", "");
       var inputs = document.getElementsByTagName("input");
       var selects = document.getElementsByTagName("select");
       for (var i=0; i<inputs.length; i++) {
@@ -678,7 +616,7 @@
       finddiff = false
       for (i in diffname){
          diff = diffname[i]
-         if (songs[index][diff] != null){
+         if (llsong.songs[index][diff] != null){
 
                   newOption = new Option(diff, diff)
                   diffsel.options.add(newOption)
@@ -995,7 +933,7 @@
       totalrawst = 0
       for (var i = 0; i < 9; i++) {
          totalrawst += rawattst[i]
-         groupbonus = samegroup(songs[document.getElementById('songchoice').value],cards[member[i]["cardid"]])
+         groupbonus = samegroup(llsong.songs[document.getElementById('songchoice').value],cards[member[i]["cardid"]])
          colorbonus = (mapcenter['map'] == member[i]['main'])
          if (!groupbonus && !colorbonus)
             attst[i] -= Math.round(showatt*member[i]['weight']/totalweight*0.21/1.21)
@@ -1040,7 +978,7 @@
       */
       result['minscore'] = 0;
       for (var i = 0; i < 9; i++) {
-         //result['minscore'] += Math.floor(showatt/80*member[i]['weight']*combomulti*accmulti*(mapcenter['map'] === member[i]['main'] ? 1.1 : 1)*(samegroup(songs[document.getElementById('songchoice').value],cards[member[i]["cardid"]]) ? 1.1 : 1));
+         //result['minscore'] += Math.floor(showatt/80*member[i]['weight']*combomulti*accmulti*(mapcenter['map'] === member[i]['main'] ? 1.1 : 1)*(samegroup(llsong.songs[document.getElementById('songchoice').value],cards[member[i]["cardid"]]) ? 1.1 : 1));
       }
       result['minscore'] = 1.21*totalattst/80*totalweight*combomulti*accmulti*(1+mapcenter['tapup']/100)
 

--- a/templates/llnewunit.html
+++ b/templates/llnewunit.html
@@ -8,17 +8,17 @@
    <script type="text/javascript" src="{{ url_for('static', filename='twintailosu.js') }}?v=1.01"></script>
    <link rel="shortcut icon" href="/static/shortcuticon.png" />
    <style type="text/css">
-   	img {height:65px;width:65px}
+      img {height:65px;width:65px}
       input[type="number"][size="3"] {
-       width: 50px;
-     }
-     input[type="number"][size="2"] {
-       width: 33px;
-     }
-     input::-webkit-inner-spin-button {
-       -webkit-appearance: none;
-       margin: 0;
-     }
+         width: 60px;
+      }
+      input[type="number"][size="2"] {
+         width: 50px;
+      }
+      input::-webkit-inner-spin-button {
+         -webkit-appearance: none;
+         margin: 0;
+      }
    </style>
 {% endblock %}
 
@@ -32,13 +32,13 @@
    defaultsong["jpname"] = "默认曲目（缪）"
    defaultsong["muse"] = 1
    defaultsong["aqours"] = 0
-   defaultsong['attribute'] = 'smile'
+   defaultsong['attribute'] = ''
    var defaultsong2 = new Array()
    defaultsong2["name"] = "默认曲目（水）"
    defaultsong2["jpname"] = "默认曲目（水）"
    defaultsong2["muse"] = 0
    defaultsong2["aqours"] = 1
-   defaultsong2['attribute'] = 'smile'
+   defaultsong2['attribute'] = ''
    expert_default = new Array()
    expert_default["positionweight"] = [63.75,63.75,63.75,63.75,0,63.75,63.75,63.75,63.75]
    expert_default["combo"] = 500
@@ -67,6 +67,7 @@
    attcolor["smile"] = "red"
    attcolor["pure"] = "green"
    attcolor["cool"] = "blue"
+   attcolor[""] = "purple"
    var kizuna = new Array();
    kizuna["N"] = [25, 50]
    kizuna["R"] = [100, 200]
@@ -111,11 +112,14 @@
    var skilllevel = 0
 
    function threetonumber(three){
-      result = three
-      if (result[0] == '0'){
+      var result = three
+      if (result == '0') {
+         return 0;
+      }
+      if (result[0] == '0') {
          result = result[1]+result[2]
       }
-      if (result[0] == '0'){
+      if (result[0] == '0') {
          result = result[1]
       }
       return result
@@ -182,6 +186,8 @@
          }
          changeavatar(pos)
          changeavatar(i)
+         calslot(pos);
+         calslot(i);
          pos = -1
       }
    }
@@ -283,34 +289,31 @@
       //changecolor("cardchoice")
    }
 
-   function getsongselect(att){
-      sel = document.getElementById("songchoice");
-      var keyword = document.getElementById("songsearch").value
+   function getsongselect(songatt, songunit, keyword){
+      var sel = document.getElementById("songchoice");
       sel.options.length = 1;
-      newOption = new Option(songs["00"].name, "00")
-      newOption.style.color = attcolor[songs["00"].attribute]
-      sel.options.add(newOption)
-      newOption = new Option(songs["01"].name, "01")
-      newOption.style.color = attcolor[songs["01"].attribute]
-      sel.options.add(newOption)
-      for (index in songs){
-         if (((att == "") || (att == songs[index].attribute))){
-         if ((keyword == "") || (songs[index].name.toLowerCase().indexOf(keyword.toLowerCase()) != -1) || (songs[index].jpname.toLowerCase().indexOf(keyword.toLowerCase()) != -1) || (songs[index].type != "0")){
-            mfhave = false
-            //alert(smhave)
-               var newOption
-               if (language == 0)
-                  newOption = new Option(songs[index].name, index)
-               else
-                  newOption = new Option(songs[index].jpname, index)
-               newOption.style.color = attcolor[songs[index].attribute]
-               sel.options.add(newOption)
-
+      var songKeys = Object.keys(songs).sort();
+      for (var i = 0; i < songKeys.length; i++) {
+         var index = songKeys[i];
+         if (!((songatt == "") || (songatt == songs[index].attribute) || (songs[index].attribute == ""))) {
+            continue;
          }
+         if (!((songunit == "") || (songs[index][songunit] == 1))) {
+            continue;
          }
-         index += 1
+         if (!((keyword == "") || (songs[index].name.toLowerCase().indexOf(keyword) != -1) || (songs[index].jpname.toLowerCase().indexOf(keyword) != -1))) {
+            continue;
+         }
+         //mfhave = false
+         //alert(smhave)
+         var newOption
+         if (language == 0)
+            newOption = new Option(songs[index].name, index)
+         else
+            newOption = new Option(songs[index].jpname, index)
+         newOption.style.color = attcolor[songs[index].attribute]
+         sel.options.add(newOption)
       }
-      //changesongcolor("songchoice")
    }
 
    function havevalue(selectId, value){
@@ -323,21 +326,23 @@
    }
 
    function changesongselect(){
-   	att = document.getElementById("songatt").value
-   	var songchoice = document.getElementById("songchoice").value
-   	getsongselect(att)
-   	if (havevalue("songchoice", songchoice)){
-   		document.getElementById("songchoice").value = songchoice
-   	}
-   	changesongcolor("songchoice")
+      var songatt = document.getElementById("songatt").value
+      var songunit = document.getElementById("songunit").value
+      var songchoice = document.getElementById("songchoice").value
+      var keyword = document.getElementById("songsearch").value.toLowerCase();
+      getsongselect(songatt, songunit, keyword)
+      if (havevalue("songchoice", songchoice)){
+         document.getElementById("songchoice").value = songchoice
+      }
+      changesongcolor("songchoice")
    }
 
    function changecardselect(){
-      rarity = document.getElementById("rarity").value
-      chr = document.getElementById("chr").value
-      att = document.getElementById("att").value
-      cardtype = document.getElementById("cardtype").value
-      special = document.getElementById("special").value
+      var rarity = document.getElementById("rarity").value
+      var chr = document.getElementById("chr").value
+      var att = document.getElementById("att").value
+      var cardtype = document.getElementById("cardtype").value
+      var special = document.getElementById("special").value
       var cardchoice = document.getElementById("cardchoice").value
       getcardselect(rarity, chr, att, cardtype, special)
       if (havevalue("cardchoice", cardchoice)){
@@ -381,25 +386,33 @@
    }
 
    function changesongcolor(which){
-   	index = document.getElementById(which).value
-      diff = document.getElementById('diffchoice').value
-   	if (index != "") {
-   		c = attcolor[songs[index].attribute]
-   		document.getElementById(which).style.color = c
-         document.getElementById("secondbase").innerHTML = songs[index].attribute
-         document.getElementById("secondbase2").innerHTML = songs[index].attribute
-   		selectlist = ["map", "bonus", "bonus2"]
-   		for (i in selectlist){
-   			document.getElementById(selectlist[i]).value = songs[index].attribute
-   		}
-   		if (document.getElementById("percentage").value != 12)
-   			document.getElementById("base").value = songs[index].attribute
-   		if (document.getElementById("percentage2").value != 12)
-   			document.getElementById("base2").value = songs[index].attribute
-   		infolist = ["combo",  "time"]
-   		for (i in infolist){
-   			document.getElementById(infolist[i]).value = songs[index][diff][infolist[i]]
-   		}
+      var index = document.getElementById(which).value;
+      var diff = document.getElementById('diffchoice').value;
+      if (index != "") {
+         var songattr = songs[index].attribute;
+         if (songattr == '') {
+            songattr = document.getElementById("songatt").value;
+            if (songattr == '') {
+               songattr = document.getElementById("map").value;
+            }
+         }
+
+         var c = attcolor[songattr];
+         document.getElementById(which).style.color = c;
+         document.getElementById("secondbase").innerHTML = songattr;
+         document.getElementById("secondbase2").innerHTML = songattr;
+         selectlist = ["map", "bonus", "bonus2"];
+         for (var i in selectlist){
+            document.getElementById(selectlist[i]).value = songattr;
+         }
+         if (document.getElementById("percentage").value != 12)
+            document.getElementById("base").value = songattr;
+         if (document.getElementById("percentage2").value != 12)
+            document.getElementById("base2").value = songattr;
+         infolist = ["combo",  "time"]
+         for (i in infolist){
+            document.getElementById(infolist[i]).value = songs[index][diff][infolist[i]]
+         }
          if (document.getElementById("time").value == ""){
             document.getElementById("time").value = 110
          }
@@ -409,12 +422,12 @@
          c = parseInt(songs[index][diff].combo)
          sl = (totalweight-c)*100/0.25/c
          //document.getElementById('slider').value = sl.toFixed(1)
-   		document.getElementById("perfect").value = parseInt(parseInt(document.getElementById("combo").value)*19/20)
-   		document.getElementById("starperfect").value = 0//parseInt(parseInt(document.getElementById("star").value)*19/20)
-   		for (i = 0; i < 9; i++){
-   			document.getElementById("weight"+String(i)).value = parseFloat(songs[index][diff]["positionweight"][i])
-   		}
-   	}
+         document.getElementById("perfect").value = parseInt(parseInt(document.getElementById("combo").value)*19/20)
+         document.getElementById("starperfect").value = 0//parseInt(parseInt(document.getElementById("star").value)*19/20)
+         for (i = 0; i < 9; i++){
+            document.getElementById("weight"+String(i)).value = parseFloat(songs[index][diff]["positionweight"][i])
+         }
+      }
    }
 
    function cardidtoindex(n){
@@ -491,13 +504,13 @@
    }
 
    function changeavatar(n){
-   	cardid = threetonumber(document.getElementById('cardid'+String(n)).value)
-   	if ((cardid == 0) || (cardid == "") || (cardid == "0"))
-   		document.getElementById('avatar'+String(n)).src = '/static/null.png'
-   	else if (document.getElementById('mezame'+String(n)).value == 0)
+      var cardid = threetonumber(document.getElementById('cardid'+String(n)).value)
+      if ((cardid == 0) || (cardid == "") || (cardid == "0"))
+         document.getElementById('avatar'+String(n)).src = '/static/null.png'
+      else if (document.getElementById('mezame'+String(n)).value == 0)
          document.getElementById('avatar'+String(n)).src = getimagepath(cards[cardid]['id'],'avatar',0)
-   	else
-   		document.getElementById('avatar'+String(n)).src = getimagepath(cards[cardid]['id'],'avatar',1)
+      else
+         document.getElementById('avatar'+String(n)).src = getimagepath(cards[cardid]['id'],'avatar',1)
    }
 
    function changeavatarselect(){
@@ -607,48 +620,50 @@
    }
 
    function init(){
-   	//document.getElementById('avatar0').src = 'http://i2.tietuku.com/8baa9a87cc083022.jpg'
+      //document.getElementById('avatar0').src = 'http://i2.tietuku.com/8baa9a87cc083022.jpg'
       skilllevel = 0
-   	mezame = getCookie("mezameunit")
-   	language = getCookie("languageunit")
-   	if (mezame == "")
-   		mezame = 0
-   	if (language == "")
-   		language = 0
+      mezame = getCookie("mezameunit")
+      language = getCookie("languageunit")
+      if (mezame == "")
+         mezame = 0
+      if (language == "")
+         language = 0
 
-   	getcardselect("", "", "", "", "", "");
-   	getsongselect("", "", "", "");
-   	var inputs = document.getElementsByTagName("input");
-   	var selects = document.getElementsByTagName("select");
-   	for (var i=0; i<inputs.length; i++){
-   		if (inputs[i].type == "text")
-   			if (getCookie(inputs[i].name+"unit") != "")
-   				inputs[i].value = getCookie(inputs[i].name+"unit");
-   	}
-   	for (var i=0; i<selects.length; i++){
-   		if (getCookie(selects[i].name+"unit") != "")
-   			selects[i].value = getCookie(selects[i].name+"unit");
-   	}
-   	if (mezame == 1)
-   		document.getElementById("mezame").checked = mezame
-   	//selects["cardchoice"].value = getCookie(selects["cardchoice"].name);
-   	//selects["songchoice"].value = getCookie(selects["songchoice"].name);
+      getcardselect("", "", "", "", "", "");
+      getsongselect("", "", "", "");
+      var inputs = document.getElementsByTagName("input");
+      var selects = document.getElementsByTagName("select");
+      for (var i=0; i<inputs.length; i++) {
+         if (inputs[i].type == "text") {
+            var curCookie = getCookie(inputs[i].name+"unit");
+            if (curCookie != "") inputs[i].value = curCookie;
+         }
+      }
+      for (var i=0; i<selects.length; i++) {
+         var curCookie = getCookie(selects[i].name+"unit");
+         if (curCookie != "") selects[i].value = curCookie;
+      }
+      if (mezame == 1)
+         document.getElementById("mezame").checked = mezame
+      //selects["cardchoice"].value = getCookie(selects["cardchoice"].name);
+      //selects["songchoice"].value = getCookie(selects["songchoice"].name);
       try {
-   	changeskilltext("")
-      changeskilllevel()
-   	changeavatarselect()
-   	for (i = 0; i < 9; i++){
-   		//changeskilltext(i)
-   		changeavatar(i)
-         calslot(i)
-   	}
+         changeskilltext("")
+         changeskilllevel()
+         changeavatarselect()
+         for (i = 0; i < 9; i++){
+            //changeskilltext(i)
+            changeavatar(i)
+            calslot(i)
+         }
 
-   	document.getElementById("songsearch").value = ""
-   	//changecolor("cardchoice")
-   	//changesongcolor("songchoice")
-   	document.getElementById("songchoice").style.color = attcolor[songs[document.getElementById("songchoice").value].attribute]
-   	document.getElementById("cardchoice").style.color = attcolor[cards[document.getElementById("cardchoice").value].attribute]
-      } catch (err) {}
+         document.getElementById("songsearch").value = ""
+         // webbrowser may auto fill some fields, so we refresh it...
+         changesongselect();
+         changecardselect();
+      } catch (err) {
+        console.log(err);
+      }
 
       {{additional_script|safe}}
    }
@@ -1356,6 +1371,11 @@
 		<option value="smile">smile</option>
 		<option value="pure">pure</option>
 		<option value="cool">cool</option>
+	</select>
+	<select id="songunit" name="songunit" onchange="changesongselect()">
+		<option value="">组合</option>
+		<option value="muse">μ's</option>
+		<option value="aqours">Aqours</option>
 	</select><br>
 歌曲：<select id="songchoice" name="songchoice" onchange="changediffinfo();changesongcolor('songchoice')">
 		<option value=""> </option>
@@ -1554,7 +1574,7 @@
    <tr>
       <td>权重</td>
       {% for i in range(0,9) %}
-      <td><input type="number" step="any" id="weight{{i}}" name="weight{{i}}" size=2 autocomplete="off"></td>
+      <td><input type="number" step="any" id="weight{{i}}" name="weight{{i}}" size=3 autocomplete="off"></td>
       {% endfor %}
    </tr>
    <tr>

--- a/templates/llnewunit.html
+++ b/templates/llnewunit.html
@@ -658,7 +658,7 @@
          }
 
          document.getElementById("songsearch").value = ""
-         // webbrowser may auto fill some fields, so we refresh it...
+         // above codes may select songs/cards/filters according to cookies, so refresh it...
          changesongselect();
          changecardselect();
       } catch (err) {

--- a/templates/llnewunit.html
+++ b/templates/llnewunit.html
@@ -324,16 +324,10 @@
    }
 
    function changesongcolor(which){
-      var index = document.getElementById(which).value;
-      var diff = document.getElementById('diffchoice').value;
+      var index = llsong.getSelectedSongIndex(which);
       if (index != "") {
-         var songattr = llsong.songs[index].attribute;
-         if (songattr == '') {
-            songattr = document.getElementById("songatt").value;
-            if (songattr == '') {
-               songattr = document.getElementById("map").value;
-            }
-         }
+         var diff = document.getElementById('diffchoice').value;
+         var songattr = llsong.getSongAttr(index);
 
          var c = attcolor[songattr];
          document.getElementById(which).style.color = c;

--- a/templates/llnewunitsis.html
+++ b/templates/llnewunitsis.html
@@ -6,6 +6,7 @@
 
 {% block additional_header %}
    <script type="text/javascript" src="{{ url_for('static', filename='twintailosu.js') }}?v=1.01"></script>
+   <script type="text/javascript" src="{{ url_for('static', filename='llsong.js') }}"></script>
    <link rel="shortcut icon" href="/static/shortcuticon.png" />
    <style type="text/css">
    	img {height:65px;width:65px}
@@ -17,46 +18,18 @@
    var regS = new RegExp("&#34;", "g")
    var regS2 = new RegExp("&#39;", "g")
    var regSand = new RegExp("&amp;", "g")
-   var defaultsong = new Array()
-   defaultsong["name"] = "默认曲目（缪）"
-   defaultsong["jpname"] = "默认曲目（缪）"
-   defaultsong["muse"] = 1
-   defaultsong["aqours"] = 0
-   defaultsong['attribute'] = 'smile'
-   var defaultsong2 = new Array()
-   defaultsong2["name"] = "默认曲目（水）"
-   defaultsong2["jpname"] = "默认曲目（水）"
-   defaultsong2["muse"] = 0
-   defaultsong2["aqours"] = 1
-   defaultsong2['attribute'] = 'smile'
-   expert_default = new Array()
-   expert_default["positionweight"] = [63.75,63.75,63.75,63.75,0,63.75,63.75,63.75,63.75]
-   expert_default["combo"] = 500
-   expert_default["time"] = 110
-   expert_default["star"] = 65
-   master_default = new Array()
-   master_default["positionweight"] = [87.5,87.5,87.5,87.5,0,87.5,87.5,87.5,87.5]
-   master_default["combo"] = 700
-   master_default["time"] = 110
-   master_default["star"] = 65
-   defaultsong["expert"] = expert_default
-   defaultsong["master"] = master_default
-   defaultsong["type"] = "0"
-   defaultsong2["expert"] = expert_default
-   defaultsong2["master"] = master_default
-   defaultsong2["type"] = "0"
    var cardsjson = "{{cardsjson}}".replace(regS,'"').replace(regS2, "'").replace(regSand, '&')
    var songsjson = "{{songsjson}}".replace(regS,'"').replace(regS2, "'").replace(regSand, '&')
    var cards = eval("("+cardsjson+")")
-   var songs = eval("("+songsjson+")")
-   songs["00"] = defaultsong
-   songs["01"] = defaultsong2
+   var llsong = new LLSong(songsjson);
+
    var attcolor = new Array();
    var mezame = 0
    var language = 0
    attcolor["smile"] = "red"
    attcolor["pure"] = "green"
    attcolor["cool"] = "blue"
+   attcolor[""] = "purple"
    var kizuna = new Array();
    kizuna["N"] = [25, 50]
    kizuna["R"] = [100, 200]
@@ -119,12 +92,15 @@
 	skillcount=new Array();
 	SNum = new Array();//↓每种宝石的数量*z0
    currslot=0;
-function threetonumber(three){
-      result = three
-      if (result[0] == '0'){
+   function threetonumber(three){
+      var result = three
+      if (result == '0') {
+         return 0;
+      }
+      if (result[0] == '0') {
          result = result[1]+result[2]
       }
-      if (result[0] == '0'){
+      if (result[0] == '0') {
          result = result[1]
       }
       return result
@@ -294,36 +270,6 @@ function threetonumber(three){
       //changecolor("cardchoice")
    }
    
-   function getsongselect(att){
-      sel = document.getElementById("songchoice");
-      var keyword = document.getElementById("songsearch").value
-      sel.options.length = 1;
-      newOption = new Option(songs["00"].name, "00")
-      newOption.style.color = attcolor[songs["00"].attribute]
-      sel.options.add(newOption)
-      newOption = new Option(songs["01"].name, "01")
-      newOption.style.color = attcolor[songs["01"].attribute]
-      sel.options.add(newOption)
-      for (index in songs){
-         if (((att == "") || (att == songs[index].attribute))){
-         if ((keyword == "") || (songs[index].name.toLowerCase().indexOf(keyword.toLowerCase()) != -1) || (songs[index].jpname.toLowerCase().indexOf(keyword.toLowerCase()) != -1) || (songs[index].type != "0")){
-            mfhave = false
-            //alert(smhave)
-               var newOption
-               if (language == 0)
-                  newOption = new Option(songs[index].name, index)
-               else
-                  newOption = new Option(songs[index].jpname, index)
-               newOption.style.color = attcolor[songs[index].attribute]
-               sel.options.add(newOption)
-
-         }
-         }
-         index += 1
-      }
-      //changesongcolor("songchoice")
-   }
-   
    function havevalue(selectId, value){
    	objSelect = document.getElementById(selectId)
    	for (var i = 0; i < objSelect.options.length; i++){
@@ -334,13 +280,8 @@ function threetonumber(three){
    }
    
    function changesongselect(){
-   	att = document.getElementById("songatt").value
-   	var songchoice = document.getElementById("songchoice").value
-   	getsongselect(att)
-   	if (havevalue("songchoice", songchoice)){
-   		document.getElementById("songchoice").value = songchoice
-   	}
-   	changesongcolor("songchoice")
+      llsong.filterSongs();
+      changesongcolor("songchoice")
    }
    
    function changecardselect(){
@@ -392,40 +333,42 @@ function threetonumber(three){
    }
    
    function changesongcolor(which){
-   	index = document.getElementById(which).value
-      diff = document.getElementById('diffchoice').value
-   	if (index != "") {
-   		c = attcolor[songs[index].attribute]
-   		document.getElementById(which).style.color = c
-//         document.getElementById("secondbase").innerHTML = songs[index].attribute
-         document.getElementById("secondbase2").innerHTML = songs[index].attribute
-   		selectlist = ["map",  "bonus2"]
-   		for (i in selectlist){
-   			document.getElementById(selectlist[i]).value = songs[index].attribute
-   		}
+      var index = llsong.getSelectedSongIndex(which);
+      if (index != "") {
+         var diff = document.getElementById('diffchoice').value;
+         var songattr = llsong.getSongAttr(index);
+
+         var c = attcolor[songattr];
+         document.getElementById(which).style.color = c;
+//         document.getElementById("secondbase").innerHTML = songattr;
+         document.getElementById("secondbase2").innerHTML = songattr;
+         selectlist = ["map", "bonus2"];
+         for (var i in selectlist) {
+            document.getElementById(selectlist[i]).value = songattr;
+         }
 //   		if (document.getElementById("percentage").value != 12)
-//   			document.getElementById("base").value = songs[index].attribute
-   		if (document.getElementById("percentage2").value != 12)
-   			document.getElementById("base2").value = songs[index].attribute
-   		infolist = ["combo",  "time"]
-   		for (i in infolist){
-   			document.getElementById(infolist[i]).value = songs[index][diff][infolist[i]]
-   		}
+//   			document.getElementById("base").value = songattr;
+         if (document.getElementById("percentage2").value != 12)
+            document.getElementById("base2").value = songattr;
+         infolist = ["combo",  "time"]
+         for (i in infolist){
+            document.getElementById(infolist[i]).value = llsong.songs[index][diff][infolist[i]]
+         }
          if (document.getElementById("time").value == ""){
             document.getElementById("time").value = 110
          }
          totalweight = 0
          for (i = 0; i < 9; i++)
-            totalweight += parseFloat(songs[index][diff]['positionweight'][i])
-         c = parseInt(songs[index][diff].combo)
+            totalweight += parseFloat(llsong.songs[index][diff]['positionweight'][i])
+         c = parseInt(llsong.songs[index][diff].combo)
          sl = (totalweight-c)*100/0.25/c
          //document.getElementById('slider').value = sl.toFixed(1)
-   		document.getElementById("perfect").value = parseInt(parseInt(document.getElementById("combo").value)*19/20)
-   		document.getElementById("starperfect").value = 0//parseInt(parseInt(document.getElementById("star").value)*19/20)
-   		for (i = 0; i < 9; i++){
-   			document.getElementById("weight"+String(i)).value = parseFloat(songs[index][diff]["positionweight"][i])
-   		}
-   	}
+         document.getElementById("perfect").value = parseInt(parseInt(document.getElementById("combo").value)*19/20)
+         document.getElementById("starperfect").value = 0//parseInt(parseInt(document.getElementById("star").value)*19/20)
+         for (i = 0; i < 9; i++){
+            document.getElementById("weight"+String(i)).value = parseFloat(llsong.songs[index][diff]["positionweight"][i])
+         }
+      }
    }
    
    function cardidtoindex(n){
@@ -539,13 +482,12 @@ function threetonumber(three){
    }
    
    function changeLanguage(){
-   	var cardchoice = document.getElementById("cardchoice").value
-   	var songchoice = document.getElementById("songchoice").value
-   	language = 1-language
-   	changecardselect()
-   	changesongselect()
-   	document.getElementById("cardchoice").value = cardchoice
-   	document.getElementById("songchoice").value = songchoice
+      var cardchoice = document.getElementById("cardchoice").value
+      language = 1-language
+      llsong.language = language;
+      changecardselect()
+      changesongselect()
+      document.getElementById("cardchoice").value = cardchoice
    }
    
    function changeskilltext(n){
@@ -644,8 +586,9 @@ function threetonumber(three){
    	if (language == "")
    		language = 0
    	
+      llsong.language = language;
+      llsong.showAllSongs();
    	getcardselect("", "", "", "", "", "");
-   	getsongselect("", "", "", "");
    	var inputs = document.getElementsByTagName("input");
    	var selects = document.getElementsByTagName("select");
    	for (var i=0; i<inputs.length; i++){
@@ -672,10 +615,9 @@ function threetonumber(three){
    	}
       
    	document.getElementById("songsearch").value = ""
-   	//changecolor("cardchoice")
-   	//changesongcolor("songchoice")
-   	document.getElementById("songchoice").style.color = attcolor[songs[document.getElementById("songchoice").value].attribute]
-   	document.getElementById("cardchoice").style.color = attcolor[cards[document.getElementById("cardchoice").value].attribute]
+         // above codes may select songs/cards/filters according to cookies, so refresh it...
+         changesongselect();
+         changecardselect();
       } catch (err) {}
 
       {{additional_script|safe}}
@@ -691,7 +633,7 @@ function threetonumber(three){
       finddiff = false
       for (i in diffname){
          diff = diffname[i]
-         if (songs[index][diff] != null){
+         if (llsong.songs[index][diff] != null){
 
                   newOption = new Option(diff, diff)
                   diffsel.options.add(newOption)
@@ -1351,7 +1293,7 @@ function calc_bestarm(){
       totalrawst = 0
       for (var i = 0; i < 9; i++) {
          totalrawst += rawattst[i]
-         groupbonus = samegroup(songs[document.getElementById('songchoice').value],cards[member[i]["cardid"]])
+         groupbonus = samegroup(llsong.songs[document.getElementById('songchoice').value],cards[member[i]["cardid"]])
          colorbonus = (mapcenter['map'] == member[i]['main'])
          if (!groupbonus && !colorbonus)
             attst[i] -= Math.round(showatt*member[i]['weight']/totalweight*0.21/1.21)
@@ -1396,7 +1338,7 @@ function calc_bestarm(){
       */
       result['minscore'] = 0;
       for (var i = 0; i < 9; i++) {
-         //result['minscore'] += Math.floor(showatt/80*member[i]['weight']*combomulti*accmulti*(mapcenter['map'] === member[i]['main'] ? 1.1 : 1)*(samegroup(songs[document.getElementById('songchoice').value],cards[member[i]["cardid"]]) ? 1.1 : 1));
+         //result['minscore'] += Math.floor(showatt/80*member[i]['weight']*combomulti*accmulti*(mapcenter['map'] === member[i]['main'] ? 1.1 : 1)*(samegroup(llsong.songs[document.getElementById('songchoice').value],cards[member[i]["cardid"]]) ? 1.1 : 1));
       }
       result['minscore'] = 1.21*totalattst/80*totalweight*combomulti*accmulti*(1+mapcenter['tapup']/100)
       
@@ -1688,6 +1630,11 @@ function calc_bestarm(){
 		<option value="smile">smile</option>
 		<option value="pure">pure</option>
 		<option value="cool">cool</option>
+	</select>
+	<select id="songunit" name="songunit" onchange="changesongselect()">
+		<option value="">组合</option>
+		<option value="muse">μ's</option>
+		<option value="aqours">Aqours</option>
 	</select><br>
 歌曲：<select id="songchoice" name="songchoice" onchange="changediffinfo();changesongcolor('songchoice')">
 		<option value=""> </option>

--- a/templates/llsongdata.html
+++ b/templates/llsongdata.html
@@ -6,6 +6,7 @@
 
 {% block additional_header %}
    <script type="text/javascript" src="{{ url_for('static', filename='twintailosu.js') }}"></script>
+   <script type="text/javascript" src="{{ url_for('static', filename='llsong.js') }}"></script>
    <link rel="shortcut icon" href="/static/shortcuticon.png" />
    <style type="text/css">
    	td {size:2}
@@ -18,93 +19,8 @@
    var regS2 = new RegExp("&#39;", "g")
    var regSand = new RegExp("&amp;", "g")
    var songsjson = "{{songsjson}}".replace(regS,'"').replace(regS2, "'").replace(regSand, '&')
-   var songs = eval("("+songsjson+")")
-   var attcolor = new Array();
+   var llsong = new LLSong(songsjson);
    var language = 0
-   attcolor["smile"] = "red"
-   attcolor["pure"] = "green"
-   attcolor["cool"] = "blue"
-   
-   function getsongselect(diff, att, cnhave, type){
-   	sel = document.getElementById("songchoice");
-      diffc = document.getElementById('diff').value
-   	var keyword = document.getElementById("search").value
-   	var smnum = ''
-      var mfnum = ''
-   	sel.options.length = 1;
-   	for (index in songs){
-   		if (((att == "") || (att == songs[index].attribute)) && ((cnhave == "") || (cnhave == songs[index]['hard']['cnhave'])) && ((type == "") || (songs[index].type.indexOf(type) != -1))){
-   		if ((keyword == "") || (songs[index].name.toLowerCase().indexOf(keyword.toLowerCase()) != -1) || (songs[index].jpname.toLowerCase().indexOf(keyword.toLowerCase()) != -1)){
-   			smhave = false
-   			if (smnum != ""){
-               if (diffc == ''){
-   			      smList = songs[index]['hard'].sm.split(" ")
-                  if (songs[index]['expert'] != null)
-                     smList = (songs[index]['hard'].sm+' '+songs[index]['expert'].sm).split(" ")
-               }
-               else if (diffc == 'expert'){
-                  smList = []
-                  if (songs[index]['expert'] != null)
-                     smList = songs[index]['expert'].sm.split(" ")
-               }
-               else{
-                  smList = songs[index]['hard'].sm.split(" ")
-               }
-   				for (i in smList){
-   					if (smnum == smList[i]){
-   						smhave = true
-   						break
-   					}
-   				}
-   			}
-            mfhave = false
-            if (mfnum != ""){
-               if (diffc == ''){
-                  mfList = songs[index]['hard'].mf.split(" ")
-                  if (songs[index]['expert'] != null)
-                     mfList = (songs[index]['hard'].mf+' '+songs[index]['expert'].mf).split(" ")
-               }
-               else if (diffc == 'expert'){
-                  mfList = []
-                  if (songs[index]['expert'] != null)
-                     mfList = songs[index]['expert'].mf.split(" ")
-               }
-               else{
-                  mfList = songs[index]['hard'].mf.split(" ")
-               }
-               for (i in mfList){
-                  if (mfnum == mfList[i]){
-                     mfhave = true
-                     break
-                  }
-               }
-            }
-   			//alert(smhave)
-   			if (((smnum == "") || smhave) && ((mfnum == "") || mfhave)){
-   				var newOption
-   				if (language == 0)
-   					newOption = new Option(songs[index].name, index)
-   				else
-   					newOption = new Option(songs[index].jpname, index)
-   				newOption.style.color = attcolor[songs[index].attribute]
-   				sel.options.add(newOption)
-   			}
-            
-   		}
-   		}
-   		index += 1
-   	}
-   	//changesongcolor("songchoice")
-   }
-   
-   function havevalue(selectId, value){
-   	objSelect = document.getElementById(selectId)
-   	for (var i = 0; i < objSelect.options.length; i++){
-   		if (objSelect.options[i].value == value)
-   			return true;
-   	}
-   	return false;
-   }
    
    function kizuna(combo){
    	var result = 0
@@ -139,170 +55,169 @@
    }
    
    function changesongselect(){
-   	diff = document.getElementById("diff").value
-   	att = document.getElementById("songatt").value
-   	//type = document.getElementById("songtype").value
-   	var songchoice = document.getElementById("songchoice").value
-   	getsongselect(diff, att, '', '')
-   	if (havevalue("songchoice", songchoice)){
-   		document.getElementById("songchoice").value = songchoice
-   	}
-   	changesonginfo("songchoice")
+      llsong.filterSongs();
+      changesonginfo("songchoice")
    }
    
    function changediffinfo(){
-      savediff = document.getElementById('diffchoice').value
-      index = document.getElementById('songchoice').value
-      diffc = document.getElementById('diff').value
+      var index = llsong.getSelectedSongIndex();
+      var diffsel = document.getElementById('diffchoice');
+      var savediff = diffsel.value;
+      var songdiff = document.getElementById('songdiff').value
       //smnum =document.getElementById("smfilter").value
       //mfnum =document.getElementById("mffilter").value
 
-      diffsel = document.getElementById('diffchoice')
       diffsel.options.length = 0;
-      diffname = ['easy', 'normal', 'hard', 'expert', 'master']
-      finddiff = false
-      //if (index == '')
-      //   return
-      for (i in diffname){
-         diff = diffname[i]
-         if (songs[index][diff] != null){
-            cnhave = ''
-            if (((songs[index][diff]['cnhave'] == cnhave) || (cnhave == '')) && ((diffc == '') || (diff == diffc))) {
-
-                  newOption = new Option(diff, diff)
-                  diffsel.options.add(newOption)
-                  if (savediff == diff){
-                     document.getElementById('diffchoice').value = savediff
-                     finddiff = true
+      if (index == '') return;
+      var diffname = ['easy', 'normal', 'hard', 'expert', 'master'];
+      var finddiff = false;
+      var curSong = llsong.songs[index];
+      for (var i in diffname){
+         var diff = diffname[i];
+         var curSongWithDiff = curSong[diff];
+         if (curSongWithDiff){
+            cnhave = '';
+            if (((curSongWithDiff['cnhave'] == cnhave) || (cnhave == ''))) {
+               var newOption = new Option(diff, diff);
+               diffsel.options.add(newOption);
+               if (savediff == diff){
+                  diffsel.value = savediff;
+                  finddiff = true;
                }
             }
          }
       }
-      if (!finddiff)
-         document.getElementById('diffchoice').value = 'expert'
+      if (!finddiff) {
+         if (songdiff != "") {
+            diffsel.value = songdiff;
+         } else {
+            diffsel.value = 'expert';
+         }
+      }
       return 
    }
 
    function changesonginfo(which){
-      index = document.getElementById(which).value
-   	diff = document.getElementById('diffchoice').value
-   	if (index != "") {
-   		c = attcolor[songs[index].attribute]
-   		document.getElementById(which).style.color = c
-   		
-   		document.getElementById("attribute").innerHTML = songs[index].attribute
-   		//改颜色
-   		colorList = ["attribute", "name","jpname"]
-   		for (i in colorList){
-   			document.getElementById(colorList[i]).style.color = c
-   		}
-   		
-         songinfolist = ["totaltime","bpm","name","jpname"]
-   		diffinfolist = ["combo", "time", "stardifficulty", "randomdifficulty","star",  "cscore", "bscore", "ascore", "sscore","lp","exp"]
-   		songextend = ["秒", "", "", ""]
-         diffextend = ["", "秒", "", "", "",  "", "", "", "", "", "", "", "","","","","",""]
-   		if (songs[index]['jpname'] == songs[index]['name']){
-   			document.getElementById("name").style.display = "none"
-   			document.getElementById("cnametag").style.display = "none"
-   		}
-   		else{
-   			document.getElementById("name").style.display = ""
-   			document.getElementById("cnametag").style.display = ""
-   		}
-   		for (i in songinfolist){
-   			document.getElementById(songinfolist[i]).innerHTML = songs[index][songinfolist[i]]+songextend[i]
-   		}
-         for (i in diffinfolist){
-            document.getElementById(diffinfolist[i]).innerHTML = songs[index][diff][diffinfolist[i]]+diffextend[i]
+      var index = llsong.getSelectedSongIndex(which);
+      if (index != "") {
+         var diff = document.getElementById('diffchoice').value;
+         var songAttr = llsong.getSongAttr(index);
+         var curSong = llsong.songs[index];
+         var curSongWithDiff = curSong[diff];
+         var c = llsong.attcolor[songAttr];
+         document.getElementById(which).style.color = c;
+         document.getElementById("attribute").innerHTML = songAttr;
+         //改颜色
+         colorList = ["attribute", "name","jpname"]
+         for (i in colorList){
+            document.getElementById(colorList[i]).style.color = c;
          }
-   			
-         
-   		arraylist = ["positionweight"]
-   		for (i in arraylist){
-   			for (j = 0; j < 9; j++){
-   				document.getElementById(arraylist[i]+String(j)).innerHTML=songs[index][diff][arraylist[i]][j]
-   			}
-   		}
+
+         songinfolist = ["totaltime","bpm","name","jpname"]
+         diffinfolist = ["combo", "time", "stardifficulty", "randomdifficulty","star",  "cscore", "bscore", "ascore", "sscore","lp","exp"]
+         songextend = ["秒", "", "", ""]
+         diffextend = ["", "秒", "", "", "",  "", "", "", "", "", "", "", "","","","","",""]
+         if (curSong['jpname'] == curSong['name']){
+            document.getElementById("name").style.display = "none"
+            document.getElementById("cnametag").style.display = "none"
+         }
+         else{
+            document.getElementById("name").style.display = ""
+            document.getElementById("cnametag").style.display = ""
+         }
+         for (i in songinfolist){
+            document.getElementById(songinfolist[i]).innerHTML = curSong[songinfolist[i]]+songextend[i]
+         }
+         for (i in diffinfolist){
+            document.getElementById(diffinfolist[i]).innerHTML = curSong[diff][diffinfolist[i]]+diffextend[i]
+         }
+
+         arraylist = ["positionweight"]
+         for (i in arraylist){
+            for (j = 0; j < 9; j++){
+               document.getElementById(arraylist[i]+String(j)).innerHTML=curSong[diff][arraylist[i]][j]
+            }
+         }
          totalweight = 0
          for (i = 0; i < 9; i++)
-            totalweight += parseFloat(songs[index][diff]['positionweight'][i])
-   		c = parseInt(songs[index][diff].combo)
-   		sl = (totalweight-c)*100/0.25/c
+            totalweight += parseFloat(curSongWithDiff['positionweight'][i])
+         c = parseInt(curSongWithDiff.combo)
+         sl = (totalweight-c)*100/0.25/c
          document.getElementById('noteweight').innerHTML = String(totalweight)
-   		for (i = 0; i < 9; i++){
-   			p = parseFloat(songs[index][diff].positionweight[i])
-   			percentage = p/(c*(1+0.0025*sl))
-   			document.getElementById("positionmulti"+String(i)).innerHTML=String((10*percentage).toFixed(3))+"%"
-   		}
-   		//隐藏没有的信息
-   		hidelist = ["randomdifficulty"]
-   		for (i in hidelist){
-   			if (songs[index][diff][hidelist[i]] == ""){
-   				document.getElementById(hidelist[i]).style.display = "none"
-   				document.getElementById(hidelist[i]+"tag").style.display = "none"
-   			}
-   			else{
-   				document.getElementById(hidelist[i]).style.display = ""
-   				document.getElementById(hidelist[i]+"tag").style.display = ""
-   			}
-   		}
-   		//其他信息
-   		document.getElementById("kizunaget").innerHTML = kizuna(parseInt(songs[index][diff].combo))
-   		document.getElementById("combomulti").innerHTML = combomulti(parseInt(songs[index][diff].combo)).toFixed(3)
-   		document.getElementById("scoreperstrength").innerHTML = (1.1*1.1/80*combomulti(c)*totalweight).toFixed(3)
-   		
-   		//属性需求信息
-   		cbmulti = combomulti(parseInt(songs[index][diff].combo))
-   		rankList = ['c', 'b', 'a', 's']
-   		for (i in rankList){
-   			if (songs[index][diff][rankList+"score"] == "")
-   				continue
-   			//document.getElementById(rankList[i]+"lowatt").innerHTML = parseInt(parseInt(songs[index][diff][rankList[i]+"score"])/cbmulti/c/(1+0.0025*sl)*80/1.1)
-   			//document.getElementById(rankList[i]+"stableatt").innerHTML = parseInt(parseInt(songs[index][diff][rankList[i]+"score"])/c/(1+0.0025*sl)/0.99*80/1.1)
-   		}
-   		
-   		//高亮低权重位置
-   		we = new Array(8)
-   		po = [0, 1, 2 ,3 ,5 ,6, 7, 8]
-   		for (i = 0; i < 4; i++){
-   			we[i] = parseFloat(songs[index][diff].positionweight[i])
-   		}
-   		for (i = 5; i < 9; i++){
-   			we[i-1] = parseFloat(songs[index][diff].positionweight[i])
-   		}
-   		for (i = 0; i < 8; i ++){
-   			for (j = 0; j < 7; j++){
-   				if (we[j] > we[j+1]){
-   					tmp = we[j]
-   					we[j] = we[j+1]
-   					we[j+1] = tmp
-   					tmp = po[j]
-   					po[j] = po[j+1]
-   					po[j+1] = tmp
-   				}
-   			}
-   		}
-		for (i = 0; i < 9; i++){
-   			document.getElementById("positionweight"+String(i)).style.background = ""
-   		}
-    		document.getElementById("positionweight"+String(po[0])).style.background = "#f2dede"
-    		document.getElementById("positionweight"+String(po[0])).style.color = "#a94442"
-    		document.getElementById("positionweight"+String(po[1])).style.background = "#fcf8e3"
-    		document.getElementById("positionweight"+String(po[1])).style.color = "#8a6d3b"
-    		document.getElementById("positionweight"+String(po[2])).style.background = "#ffffcc"
-    		document.getElementById("positionweight"+String(po[2])).style.color = "#a0a003"
-   	}
+         for (i = 0; i < 9; i++){
+            p = parseFloat(curSongWithDiff.positionweight[i])
+            percentage = p/(c*(1+0.0025*sl))
+            document.getElementById("positionmulti"+String(i)).innerHTML=String((10*percentage).toFixed(3))+"%"
+         }
+         //隐藏没有的信息
+         hidelist = ["randomdifficulty"]
+         for (i in hidelist){
+            if (curSongWithDiff[hidelist[i]] == ""){
+               document.getElementById(hidelist[i]).style.display = "none"
+               document.getElementById(hidelist[i]+"tag").style.display = "none"
+            }
+            else{
+               document.getElementById(hidelist[i]).style.display = ""
+               document.getElementById(hidelist[i]+"tag").style.display = ""
+            }
+         }
+         //其他信息
+         document.getElementById("kizunaget").innerHTML = kizuna(parseInt(curSongWithDiff.combo))
+         document.getElementById("combomulti").innerHTML = combomulti(parseInt(curSongWithDiff.combo)).toFixed(3)
+         document.getElementById("scoreperstrength").innerHTML = (1.1*1.1/80*combomulti(c)*totalweight).toFixed(3)
+
+         //属性需求信息
+         cbmulti = combomulti(parseInt(curSongWithDiff.combo))
+         rankList = ['c', 'b', 'a', 's']
+         for (i in rankList){
+            if (curSongWithDiff[rankList+"score"] == "")
+               continue
+            //document.getElementById(rankList[i]+"lowatt").innerHTML = parseInt(parseInt(curSongWithDiff[rankList[i]+"score"])/cbmulti/c/(1+0.0025*sl)*80/1.1)
+            //document.getElementById(rankList[i]+"stableatt").innerHTML = parseInt(parseInt(curSongWithDiff[rankList[i]+"score"])/c/(1+0.0025*sl)/0.99*80/1.1)
+         }
+
+         //高亮低权重位置
+         we = new Array(8)
+         po = [0, 1, 2 ,3 ,5 ,6, 7, 8]
+         for (i = 0; i < 4; i++){
+            we[i] = parseFloat(curSongWithDiff.positionweight[i])
+         }
+         for (i = 5; i < 9; i++){
+            we[i-1] = parseFloat(curSongWithDiff.positionweight[i])
+         }
+         for (i = 0; i < 8; i ++){
+            for (j = 0; j < 7; j++){
+               if (we[j] > we[j+1]){
+                  tmp = we[j]
+                  we[j] = we[j+1]
+                  we[j+1] = tmp
+                  tmp = po[j]
+                  po[j] = po[j+1]
+                  po[j+1] = tmp
+               }
+            }
+         }
+         for (i = 0; i < 9; i++){
+            document.getElementById("positionweight"+String(i)).style.background = ""
+         }
+         document.getElementById("positionweight"+String(po[0])).style.background = "#f2dede"
+         document.getElementById("positionweight"+String(po[0])).style.color = "#a94442"
+         document.getElementById("positionweight"+String(po[1])).style.background = "#fcf8e3"
+         document.getElementById("positionweight"+String(po[1])).style.color = "#8a6d3b"
+         document.getElementById("positionweight"+String(po[2])).style.background = "#ffffcc"
+         document.getElementById("positionweight"+String(po[2])).style.color = "#a0a003"
+      }
    }
    
    function changeLanguage(){
-   	var songchoice = document.getElementById("songchoice").value
-   	language = 1-language
-	changesongselect()
-   	document.getElementById("songchoice").value = songchoice
+   	  language = 1-language
+      llsong.language = language;
+	  changesongselect()
    }
    
    function init(){
-   	getsongselect("", "", "", "");
+      //llsong.filterSongs();
+	  changesongselect()
    }
    
    document.addEventListener("change", function () {
@@ -329,18 +244,24 @@
 <label class="control-label">搜索</label><input class="form-control" type="text" id="search" value="" onchange="changesongselect()"></input>
 </div>
 <div class="form-group">
-<label class="control-label">筛选</label><select class="form-control" id="diff" name="diff" onchange="changesongselect();changediffinfo()" style="display:none">
+<label class="control-label">筛选</label><select class="form-control" id="songdiff" name="songdiff" onchange="changesongselect();changediffinfo()">
 		<option value="">难度</option>
-		<option value="easy">easy</option>
-		<option value="normal">normal</option>
-		<option value="hard">hard</option>
-		<option value="expert">expert</option>
+		<option value="easy">包含easy难度</option>
+		<option value="normal">包含normal难度</option>
+		<option value="hard">包含hard难度</option>
+		<option value="expert">包含expert难度</option>
+		<option value="master">包含master难度</option>
 	</select>
 	<select class="form-control" id="songatt" name="songatt" onchange="changesongselect()">
 		<option value="">属性</option>
 		<option value="smile">Smile</option>
 		<option value="pure">Pure</option>
 		<option value="cool">Cool</option>
+	</select>
+	<select class="form-control" id="songunit" name="songunit" onchange="changesongselect()">
+		<option value="">组合</option>
+		<option value="muse">μ's</option>
+		<option value="aqours">Aqours</option>
 	</select>
 </div>
    <!--


### PR DESCRIPTION
New features:
* Add song filter for μ's and Aqours
* Default song now show in purple color instead of red

Fixes:
* Fixed song search
* Fixed exception in init
* Swap cards also swap slot number now (in `llnewunit` only)
* Song filter selection now is kept after refresh
* Increased number input box size (in `llnewunit` only)
* The song filter experience is now consistent accross all pages

Enhancement for developer:
* Moved song filter logic to a js file and reuse in `llnewunit`, `llnewunitsis`, `llsongdata`, `llnewautounit`, `llcoverage`